### PR TITLE
Refactor compatibility for Python configuration parsing

### DIFF
--- a/notmuch/compat.py
+++ b/notmuch/compat.py
@@ -25,7 +25,7 @@ Copyright 2012 Justus Winter <4winter@informatik.uni-hamburg.de>
 import sys
 
 if sys.version_info[0] == 2:
-    from ConfigParser import SafeConfigParser
+    from ConfigParser import ConfigParser
 
     class Python3StringMixIn(object):
         def __str__(self):
@@ -47,7 +47,7 @@ if sys.version_info[0] == 2:
 
         return value
 else:
-    from configparser import SafeConfigParser
+    from configparser import ConfigParser
 
     class Python3StringMixIn(object):
         def __str__(self):
@@ -66,6 +66,6 @@ else:
 
         return value.encode('utf-8', 'replace')
 
-# We import the SafeConfigParser class on behalf of other code to cope
+# We import the ConfigParser class on behalf of other code to cope
 # with the differences between Python 2 and 3.
-SafeConfigParser # avoid warning about unused import
+ConfigParser # avoid warning about unused import

--- a/notmuch/database.py
+++ b/notmuch/database.py
@@ -21,7 +21,7 @@ import os
 import codecs
 import warnings
 from ctypes import c_char_p, c_void_p, c_uint, byref, POINTER
-from .compat import SafeConfigParser
+from .compat import ConfigParser
 from .globals import (
     nmlib,
     Enum,
@@ -668,10 +668,10 @@ class Database(object):
         """ Reads a user's notmuch config and returns his db location
 
         Throws a NotmuchError if it cannot find it"""
-        config = SafeConfigParser()
+        config = ConfigParser()
         conf_f = os.getenv('NOTMUCH_CONFIG',
                            os.path.expanduser('~/.notmuch-config'))
-        config.readfp(codecs.open(conf_f, 'r', 'utf-8'))
+        config.read_file(codecs.open(conf_f, 'r', 'utf-8'))
         if not config.has_option('database', 'path'):
             raise NotmuchError(message="No DB path specified"
                                        " and no user default found")


### PR DESCRIPTION
- Updated import statements in compat.py to use `ConfigParser` instead of `SafeConfigParser`.
- Modified database.py to utilize the updated `ConfigParser` class.
- Replaced deprecated `readfp` method with `read_file` in database.py.

For more information see: https://docs.python.org/3/whatsnew/3.12.html#configparser